### PR TITLE
Delete old screenshots and allow audio recording for non-owners

### DIFF
--- a/src/entry/editor.js
+++ b/src/entry/editor.js
@@ -14,7 +14,7 @@ export function editorMain() {
     async function doNext(str) {
         var list = str.split(",");
         OS.path = list[1] == "0" ? list[0] + "/" : undefined;
-        if (window.canSave) await setupMediaRecording();
+        await setupMediaRecording();
         Record.available = audioRecorderAvailable();
         Camera.available = videoRecorderAvailable();
         ScratchJr.appinit(window.Settings.scratchJrVersion);

--- a/src/tablet/Web.js
+++ b/src/tablet/Web.js
@@ -64,7 +64,11 @@ export async function setupMediaRecording() {
             Record.setButtonsEnabled(false);
 
             try {
-                latestAudioURL = await window.uploadAudio(audioBlob);
+                if (window.canSave) {
+                    latestAudioURL = await window.uploadAudio(audioBlob);
+                } else {
+                    latestAudioURL = URL.createObjectURL(audioBlob);
+                }
             } catch (err) {
                 console.log("Audio upload error!", err);
                 return;
@@ -239,6 +243,12 @@ export default class Web {
 
     static registerSound(dir, name, fcn) {
         (async () => {
+            // In this case, the user can not save the project, so we don't upload
+            // the audio to the server and instead just use a blob URL
+            if (name.startsWith('blob:')) {
+                dir = '';
+            }
+
             const url = absoluteURL(dir + name);
             console.log("registerSound", dir, name);
             const response = await fetch(url);

--- a/src/tablet/WebDB.js
+++ b/src/tablet/WebDB.js
@@ -476,6 +476,10 @@ export async function saveToProjectFiles(fileMD5, content) {
             values: [fileMD5, content],
         });
 
+        await executeStatementFromJSON({
+            stmt: `vacuum;`,
+        });
+
         saveDB();
     }
 }

--- a/src/tablet/WebDB.js
+++ b/src/tablet/WebDB.js
@@ -358,20 +358,21 @@ export async function executeStatementFromJSON(json) {
     return lastRowId;
 }
 
-// https://github.com/jfo8000/ScratchJr-Desktop/blob/master/src/main.js#L842
+/**
+ * Saves the current state of the stage as a screenshot to the database.
+ * 
+ * It's confusing because they refer to this table as the projectfiles table, but
+ * its just screenshots. There are just 2 columns, 1 for filename (fileMD5), and
+ * one for the content (which is just a data URI string). We delete all the previous
+ * screenshots every time we update it because we don't need to keep them around.
+ * 
+ * Reference: https://github.com/jfo8000/ScratchJr-Desktop/blob/master/src/main.js#L842
+ * 
+ * @param {string} fileMD5
+ * @param {string} content
+ */
 export async function saveToProjectFiles(fileMD5, content) {
-    /**
-     * Function to save project content to local storage
-     * Local storage format-
-     * [
-     *      {
-     *          'columns': ['MD5', 'CONTENTS']
-     *          'values': [ ..., [fileMD5, content] ]
-     *      }
-     * ]
-     * @param {string} fileMD5
-     * @param {string} content
-     */
+    
     // query for the current file contents to see if they actually changed
     let currentContents = "";
     const queryResult = JSON.parse(
@@ -391,7 +392,7 @@ export async function saveToProjectFiles(fileMD5, content) {
     // if the contents changed, update the db and save
     if (content !== currentContents) {
         await executeStatementFromJSON({
-            stmt: `insert or replace into projectfiles (md5, contents) values (?, ?)`,
+            stmt: `delete from projectfiles; insert into projectfiles (md5, contents) values (?, ?)`,
             values: [fileMD5, content],
         });
 

--- a/src/utils/lib.js
+++ b/src/utils/lib.js
@@ -18,15 +18,19 @@ export const isAndroid = typeof AndroidInterface != "undefined";
 
 export function absoluteURL(url) {
     // if it's already an absolute URL, just return it
-    if (url.startsWith('http://') || url.startsWith('https://')) {
+    if (
+        url.startsWith("http://") ||
+        url.startsWith("https://") ||
+        url.startsWith("blob:")
+    ) {
         return url;
     }
     // remove leading dot slash
-    if (url.startsWith('./')) {
+    if (url.startsWith("./")) {
         url = url.substring(2);
     }
     // remove leading slash
-    if (url.startsWith('/')) {
+    if (url.startsWith("/")) {
         url = url.substring(1);
     }
     return ASSET_BASE_URL + url;


### PR DESCRIPTION
@dkrame11 

Currently we dont delete old screenshots and they accumulate in the database on each save, which can cause the ScratchJr program to exceed the max size even if the program does not use a lot of assets. This should fix that issue.

[Slack thread](https://codehs.slack.com/archives/C035358NGU9/p1695930819620609)

This also fixes codehs/codehs#25511 by allowing non-owners to record audio - instead of uploading to S3, the audio is just stored in-memory since non-owners can't save and we won't need to load it again.

https://www.loom.com/share/1221ab2da1ff47b38a7a70589df9accb?sid=a6c9fc11-da5d-449f-b55d-26ee36f3bc1d

