### PR TITLE
Fix saving thumbnail

### DIFF
--- a/src/editor/ui/Project.js
+++ b/src/editor/ui/Project.js
@@ -22,28 +22,6 @@ let error = false;
 let projectbarsize = 66;
 let mediaCountBase = 1;
 
-export function getFirstProjectThumbnail(callback) {
-    var json = {};
-    json.cond = "deleted = ? AND version = ? AND gallery IS NULL";
-    json.items = ["name", "thumbnail", "id", "isgift"];
-    json.values = ["NO", "iOSv01"];
-    json.order = "ctime desc";
-    IO.query(OS.database, json, function (str) {
-        var data = JSON.parse(str);
-        if (data.length > 0) {
-            var projectData = IO.parseProjectData(data[0]);
-            var thumbnail =
-                typeof projectData.thumbnail == "string"
-                    ? JSON.parse(projectData.thumbnail)
-                    : projectData.thumbnail;
-
-            if (thumbnail && thumbnail.md5) {
-                IO.getAsset(thumbnail.md5, callback);
-            }
-        }
-    });
-}
-
 export default class Project {
     static get metadata () {
         return metadata;

--- a/src/tablet/WebDB.js
+++ b/src/tablet/WebDB.js
@@ -469,7 +469,6 @@ export async function saveToProjectFiles(fileMD5, content) {
         if (isThumbnail(fileMD5)) {
             await clearThumbnails();
             latestThumbnail = 'data:image/png;base64,' + content;
-            console.log("latestThumbnail: ", latestThumbnail);
         }
         await executeStatementFromJSON({
             stmt: `insert or replace into projectfiles (md5, contents) values (?, ?);`,

--- a/src/tablet/WebDB.js
+++ b/src/tablet/WebDB.js
@@ -1,12 +1,12 @@
 // Required to let webpack 4 know it needs to copy the wasm file to our assets
 import sqlWasm from "!!file-loader?name=sql-wasm-[contenthash].wasm!sql.js/dist/sql-wasm.wasm";
 import initSqlJs from "sql.js";
-import { getFirstProjectThumbnail } from "../editor/ui/Project.js";
 
 // see https://github.com/sql-js/sql.js/#usage
 
 let db = null;
 let initPromise;
+let latestThumbnail = null;
 
 // data store locations
 let baseKey = null;
@@ -15,11 +15,7 @@ window.getStringDBAndThumbnail = getStringDBAndThumbnail;
 
 // function to get the database as a string and the thumbnail
 async function getStringDBAndThumbnail() {
-    return new Promise(function (resolve) {
-        getFirstProjectThumbnail(function (thumbnail) {
-            resolve([UTF16StringToUTF8String(saveDB()), thumbnail]);
-        });
-    });
+    return [UTF16StringToUTF8String(saveDB()), latestThumbnail];
 }
 
 window.downloadDB = downloadDB;
@@ -239,12 +235,10 @@ export function saveDB() {
     }
 
     if (window.saveScratchJrProject) {
-        getFirstProjectThumbnail(function (thumbnail) {
-            window.saveScratchJrProject(
-                UTF16StringToUTF8String(stringData),
-                thumbnail
-            );
-        });
+        window.saveScratchJrProject(
+            UTF16StringToUTF8String(stringData),
+            latestThumbnail
+        );
     }
 
     localStorage.setItem(baseKey, dbHash);
@@ -408,12 +402,16 @@ function isThumbnail(md5) {
  * See saveToProjectFiles() for more context.
  */
 async function clearThumbnails() {
-    const rows = JSON.parse(
+    const result = JSON.parse(
         await executeQueryFromJSON({
             stmt: `select * from projectfiles`,
         })
-    )[0].values;
+    );
 
+    // early return if there are no rows in the table
+    if (!result.length) return;
+
+    const rows = result[0].values;
     const md5sToDelete = [];
     for (const row of rows) {
         const md5 = row[0];
@@ -470,6 +468,8 @@ export async function saveToProjectFiles(fileMD5, content) {
     if (content !== currentContents) {
         if (isThumbnail(fileMD5)) {
             await clearThumbnails();
+            latestThumbnail = 'data:image/png;base64,' + content;
+            console.log("latestThumbnail: ", latestThumbnail);
         }
         await executeStatementFromJSON({
             stmt: `insert or replace into projectfiles (md5, contents) values (?, ?);`,


### PR DESCRIPTION
@zgalant @dkrame11 

Fixes a few issues with the way we save thumbnails now that we're only storing one thumbnail at a time. One issue was just not handling a null/undefined edge case when clearing thumbnails - when a program is newly created there aren't any thumbnails in the database to clear yet. Another issue was a race condition - we were querying the ScratchJr DB whenever we wanted to send thumbnail data back to the CodeHS side of things, however when we were writing a new thumbnail to the database we were first clearing existing thumbnails, then saving the latest thumbnail which was executed in 2 separate queries, so it was possible for the thumbnail data query to run in between those after the existing thumbnail was cleared but before the new one was written to the DB. Now we just store the latest thumbnail data in memory and send that back to CodeHS directly instead of hitting the DB. We can _probably_ even stop storing thumbnails in the DB altogether, but leaving it in for now to keep the diff smaller.

https://www.loom.com/share/4a39b2b29db248219b6cc39545904fa7