### PR TITLE
Bugfixes and fullscreen on load

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -593,9 +593,11 @@ export default class ScratchJr {
         if (onHold) {
             return;
         }
-        e.preventDefault();
-        e.stopPropagation();
-        ScratchJr.unfocus(e);
+        if (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            ScratchJr.unfocus(e);
+        }
         ScratchJr.displayStatus("none");
         inFullscreen = true;
         UI.enterFullScreen();

--- a/src/editor/ui/Palette.js
+++ b/src/editor/ui/Palette.js
@@ -509,6 +509,9 @@ export default class Palette {
         if (pt && box2.hitRect(pt)) {
             return 'palette';
         }
+        if (Palette.overlapsWith(gn("blockspalette"), box)) {
+            return "palette";
+        }
         if (Palette.overlapsWith(gn('scripts'), box)) {
             return 'scripts';
         }

--- a/src/editor/ui/Project.js
+++ b/src/editor/ui/Project.js
@@ -123,6 +123,13 @@ export default class Project {
             ScratchJr.storyStarted = false;
             UI.needsScroll();
             ScratchJr.log('all thumbnails updated', ScratchJr.getTime(), 'sec');
+
+            // Set to fullscreen mode once project has loaded if parameter is passed in
+            if (new URLSearchParams(window.location.search).get('fullscreen') === 'true') {
+                ScratchJr.enterFullScreen();
+                gn('full').remove();
+            }
+
             if (isAndroid) {
                 AndroidInterface.notifyEditorDoneLoading();
             }

--- a/src/editor/ui/UI.js
+++ b/src/editor/ui/UI.js
@@ -564,6 +564,15 @@ export default class UI {
             var ns = newHTML("div", "addsprite", sprites);
             ns.onclick = UI.addSprite;
         }
+
+        // setup mouse scrolling
+        function scrollSpritesWheel(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            UI.scrollSpritesPanel(e.deltaY);
+        }
+
+        window.setEventHandler("wheel", scrollSpritesWheel, sprites);
     }
 
     static mascotData(page) {
@@ -762,11 +771,15 @@ export default class UI {
 
     static spriteScolling(e) {
         var pt = Events.getTargetPoint(e);
-        var deltay = Events.dragmousey - pt.y;
+        var deltaY = Events.dragmousey - pt.y;
         Events.dragmousey = pt.y;
+        UI.scrollSpritesPanel(deltaY);
+    }
+
+    static scrollSpritesPanel(deltaY) {
         var sc = gn("spritecc");
         var dy = sc.offsetTop;
-        dy -= deltay;
+        dy -= deltaY;
         var p = sc.parentNode;
         if (dy > 0) {
             dy = 0;


### PR DESCRIPTION
@zgalant @dkrame11 

- fixes [ScratchJr glitch - scrolling through characters](https://github.com/codehs/codehs/issues/25133#top)
- fixes [Deleting ScratchJr Blocks when touching the block bar](https://github.com/codehs/codehs/issues/25040#top)
- implements this for ScratchJr by adding `?fullscreen=true` to the URL: [Scratch Sandbox Links to Full Screen](https://github.com/codehs/codehs/issues/25153#top)

Loom:
https://www.loom.com/share/10a6cf4b19eb476e97fb9dada29bdd3d

Steps to test:
[Local testing setup instructions](https://www.notion.so/codehs/Scratch-ScratchJr-fae5d776041d479c914dc8fddc80517b?pvs=4#34e12e58f4c84693a2ebe034cced834f)
Add more than 4 sprites to a project, verify you can scroll the sprites panel with the mousewheel
Delete script blocks, verify they get deleted as long as they overlap with the blocks palette
Add `?fullscreen=true` to the URL, verify it enters fullscreen mode once the program loads