### PR TITLE
fixed paint fill tool

### DIFF
--- a/src/painteditor/Ghost.js
+++ b/src/painteditor/Ghost.js
@@ -148,8 +148,8 @@ export default class Ghost {
         var rpos = Paint.root.createSVGRect();
         rpos.x = pt.x;
         rpos.y = pt.y;
-        rpos.width = 1;
-        rpos.height = 1;
+        rpos.width = 100;
+        rpos.height = 100;
 
         var matches = Paint.root.getIntersectionList(rpos, null);
         if (matches !== null) {


### PR DESCRIPTION
### Resolves

Fixes issue with paint bucket not working when clicking in the middle of an object

- Fixes ENG-8488

### Proposed Changes

Makes the intersection bigger when selecting objects

### Test Coverage

https://www.loom.com/share/840ff942b8de48f68591478987410b46?sid=499c64de-84c0-4b31-b8d4-1642febc7fdf
use the various tools and make sure they're correct
