### PR TITLE
Added print when load project fails

### DIFF
--- a/src/tablet/WebDB.js
+++ b/src/tablet/WebDB.js
@@ -277,6 +277,8 @@ async function getInitialDBString() {
             dbData = result[0];
             showUploadDB = result[1];
         } else {
+            console.log("result is not an array");
+            console.log(result);
             dbData = result;
         }
         if (showUploadDB) {


### PR DESCRIPTION
### Proposed Changes

Prints when `loadScratchJrProject` does not return an array, which is the expected return type

### Reason for Changes

We have been getting more complaints about scratchjr projects not working on load
