### PR TITLE
Remove scratchJr logo [100%]

### DIFF
--- a/editions/free/src/css/editormodal.css
+++ b/editions/free/src/css/editormodal.css
@@ -39,6 +39,13 @@
     height: ${css_vh(14.71)};
     margin-left: auto;
     margin-right: auto;
+    opacity: 1;
+}
+
+.modal-backdrop.fade {
+    -webkit-transition: opacity 0.5s linear;
+    transition: opacity 0.5s linear;
+    opacity: 0;
 }
 
 .modal-body {

--- a/editions/free/src/css/lobby.css
+++ b/editions/free/src/css/lobby.css
@@ -65,16 +65,6 @@ div.frame {
     width: ${css_vh(32)};
 }
 
-#topbar ul.topbar-nav .logo .logo-icon {
-    display: block;
-    width: ${css_vh(28.65)};
-    height: ${css_vh(10.03)};
-    background: url('../assets/lobby/scratchJrlogo.svg');
-    background-size: 101%;
-    padding: 0;
-    margin: auto auto;
-}
-
 #topbar ul.topbar-nav li.home {
     width: ${css_vh(16)};
 }

--- a/editions/free/src/css/start.css
+++ b/editions/free/src/css/start.css
@@ -59,20 +59,6 @@ div.frame {
 .credits.show, .creditsText.show {display: block;}
 
 
-
-*.jrlogo {
-    position: absolute;
-    top: 26%;
-    width: 100%;
-    margin: 0px;
-    height: 16%;
-    z-index: 10;
-    background: url('../assets/start/ScratchJrLogo.svg');
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: auto 100%;
-}
-
 *.purple {
     position: absolute;
     top: 7%;

--- a/editions/free/src/index.html
+++ b/editions/free/src/index.html
@@ -28,7 +28,6 @@
         <div class="creditsText hide" id="authorsText"></div>
         <div class="rays" id="rays"></div>
         <div class="catface" id="catface"></div>
-        <div class="jrlogo" id="jrlogo"></div>
         <div class="purple hide" id="purpleguy"></div>
         <div class="red hide" id="redguy"></div>
         <div class="blue hide" id="blueguy"></div>

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -203,8 +203,6 @@ export default class ScratchJr {
         OS.hascamera();
         ScratchJr.log("starting the app");
         BlockSpecs.initBlocks();
-        Project.loadIcon = document.createElement("img");
-        Project.loadIcon.src = absoluteURL("assets/loading.png");
         ScratchJr.log(
             "blocks init",
             ScratchJr.getTime(),

--- a/src/editor/ui/Project.js
+++ b/src/editor/ui/Project.js
@@ -154,28 +154,7 @@ export default class Project {
         setProps(body.style, {
             zoom: scaleMultiplier
         });
-        if (loadIcon.complete) {
-            Project.addFeedback();
-        } else {
-            loadIcon.onload = function () {
-                Project.addFeedback();
-            };
-        }
         Project.drawBlind();
-    }
-
-    static addFeedback () {
-        var body = gn('modalbody');
-        newHTML('div', 'loadscreenfill', body);
-        newHTML('div', 'topfill', body);
-        var cover = newHTML('div', 'loadscreencover', body);
-        cover.setAttribute('id', 'progressbar');
-        var topcover = newHTML('div', 'topcover', body);
-        topcover.setAttribute('id', 'topcover');
-        var cover2 = newHTML('div', 'progressbar2', body);
-        cover2.setAttribute('id', 'progressbar2');
-        var li = newHTML('div', 'loadicon', body);
-        li.appendChild(loadIcon);
     }
 
     static setProgress (perc) {
@@ -247,13 +226,15 @@ export default class Project {
 
     static liftCurtain () {
         gn('backdrop').setAttribute('class', 'modal-backdrop fade');
-        setProps(gn('backdrop').style, {
-            display: 'none'
-        });
         gn('modaldialog').setAttribute('class', 'modal fade');
-        setProps(gn('modaldialog').style, {
-            display: 'none'
-        });
+        setTimeout(function () {
+            setProps(gn('modaldialog').style, {
+                display: 'none'
+            });
+            setProps(gn('backdrop').style, {
+                display: 'none'
+            });
+        }, 500);
     }
 
     static setLoadPage (pageid, whenDone) {

--- a/src/entry/index.js
+++ b/src/entry/index.js
@@ -149,12 +149,10 @@ function indexAskRemainingQuestions() {
 
 function hideLogo() {
     gn("catface").className = "catface hide";
-    gn("jrlogo").className = "jrlogo hide";
 }
 
 function showLogo() {
     gn("catface").className = "catface show";
-    gn("jrlogo").className = "jrlogo show";
 }
 
 function hideGear() {
@@ -217,7 +215,6 @@ function indexSetPlace(e) {
 
 function indexHidePlaceQuestion() {
     gn("catface").className = "catface show";
-    gn("jrlogo").className = "jrlogo show";
     gn("usageQuestion").className = "usageQuestion hide";
     gn("usageSchool").className = "usageSchool hide";
     gn("usageHome").className = "usageHome hide";


### PR DESCRIPTION
### Resolves

- towards ENG-14536

### Proposed Changes

Removes the ScratchJR logo from the loading screen

### Reason for Changes

We want to no longer have a commercial license with Scratch, and to do this we need to remove their logos.

### Test Coverage

- Load a scratchjr program and make sure you don't see the logo.

https://www.loom.com/share/078879ea2b3e4b309188868f5febeffd

@zgalant 
