### PR TITLE
Potential fix for scratch jr block issue 

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -13,6 +13,7 @@ import Menu from "./blocks/Menu";
 import Library from "./ui/Library";
 import Grid from "./ui/Grid";
 import ScriptsPane from "./ui/ScriptsPane";
+import Thumbs from "./ui/Thumbs";
 import Events from "../utils/Events";
 import BlockSpecs from "./blocks/BlockSpecs";
 import Runtime from "./engine/Runtime";
@@ -28,6 +29,8 @@ import {
     frame,
     mTime,
     absoluteURL,
+    setCanvasSize,
+    getDocumentHeight
 } from "../utils/lib";
 
 let workingCanvas = document.createElement("canvas");
@@ -227,6 +230,7 @@ export default class ScratchJr {
         ScratchJr.editorEvents();
         Project.load(currentProject);
         Events.init();
+        ScratchJr._initDebugHooks();
         if (window.Settings.autoSaveInterval > 0) {
             autoSaveSetInterval = window.setInterval(function () {
                 if (
@@ -308,6 +312,138 @@ export default class ScratchJr {
             return undefined;
         }
         return gn(stage.currentPage.currentSpriteName).owner;
+    }
+
+    // HACK: window.triggerDesync() reproduces the missing-watermark / disappearing-blocks bug.
+    // window.fixDesync() re-syncs using the visible script layer when possible (console).
+    // Requires 2+ sprites on the page. Swaps currentSpriteName to the OTHER
+    // sprite without toggling script-div visibility, so the user sees sprite A's
+    // scripts but drops land on sprite B's hidden div and vanish.
+    //
+    // window.triggerDesync2() reproduces the "zero-width scripts pane" bug: it sets #scripts
+    // and #scriptscontainer width to 0 the same way a bad resize can (see Page.js resize).
+    // window.fixDesync2() restores a non-zero width from layout for console recovery.
+    static _initDebugHooks() {
+        window.triggerDesync = function () {
+            var page = stage.currentPage;
+            var sprites = page.getSprites();
+            if (sprites.length < 2) {
+                console.error('Need at least 2 sprites on the page');
+                return;
+            }
+            var current = page.currentSpriteName;
+            var other = sprites.find(function (s) { return s !== current; });
+            // Swap active sprite to the other one (keeps getActiveScript() valid)
+            page.currentSpriteName = other;
+            // Clear watermark
+            var wm = ScriptsPane.watermark;
+            while (wm.childElementCount > 0) { wm.removeChild(wm.childNodes[0]); }
+            // Make switching sprites not fix it: remove the VISIBLE sprite's
+            // _scripts div so setActiveScript bails when you click its thumbnail
+            var visibleSc = gn(current + '_scripts');
+            if (visibleSc && visibleSc.parentNode) {
+                visibleSc.parentNode.removeChild(visibleSc);
+            }
+            console.warn('Active sprite is now', other, '(hidden scripts div).',
+                'Visible scripts from', current, 'are orphaned.',
+                'Clicking', current, 'thumbnail will not recover. Try dragging a block.');
+        };
+        // Prefer the script canvas that is actually visible (fixes model vs UI mismatch).
+        // Call from the console: fixDesync()
+        window.fixDesync = function () {
+            if (!stage || !stage.currentPage) {
+                console.warn('fixDesync: no active page');
+                return;
+            }
+            var dc = gn('scriptscontainer');
+            var spr = null;
+            var fromVisible = false;
+            var visibleCount = 0;
+            if (dc) {
+                for (var i = 0; i < dc.childElementCount; i++) {
+                    var node = dc.childNodes[i];
+                    if (!node.id || !/_scripts$/.test(node.id)) {
+                        continue;
+                    }
+                    if (window.getComputedStyle(node).visibility !== 'visible') {
+                        continue;
+                    }
+                    visibleCount++;
+                    if (!spr) {
+                        var sid = node.id.replace(/_scripts$/, '');
+                        var el = gn(sid);
+                        if (el && el.owner) {
+                            spr = el.owner;
+                            fromVisible = true;
+                        }
+                    }
+                }
+            }
+            if (visibleCount > 1) {
+                console.warn(
+                    'fixDesync: multiple visible script layers; using first:',
+                    spr && spr.id
+                );
+            }
+            if (!spr) {
+                spr = ScratchJr.getSprite();
+            }
+            if (spr) {
+                Thumbs.selectThisSprite(spr);
+                if (ScriptsPane.scroll) {
+                    ScriptsPane.scroll.update();
+                }
+                console.warn(
+                    'fixDesync: re-synced to',
+                    spr.id,
+                    fromVisible ? '(visible script layer)' : '(currentSpriteName / fallback)'
+                );
+            } else {
+                console.warn('fixDesync: could not resolve a sprite');
+            }
+        };
+        window.triggerDesync2 = function () {
+            var scriptsElem = gn('scripts');
+            var dc = gn('scriptscontainer');
+            if (!scriptsElem) {
+                console.error('triggerDesync2: #scripts not found');
+                return;
+            }
+            var h = Math.max(getDocumentHeight(), frame.offsetHeight);
+            var top = scriptsElem.offsetTop;
+            var height = h - top;
+            setCanvasSize(scriptsElem, 0, height);
+            if (dc) {
+                setCanvasSize(dc, 0, height);
+            }
+            console.warn(
+                'triggerDesync2: scripts pane width forced to 0 (watermark clipped, drops may not land).',
+                'Call fixDesync2() to recover.'
+            );
+        };
+        window.fixDesync2 = function () {
+            var scriptsElem = gn('scripts');
+            var dc = gn('scriptscontainer');
+            if (!scriptsElem) {
+                console.warn('fixDesync2: #scripts not found');
+                return;
+            }
+            var h = Math.max(getDocumentHeight(), frame.offsetHeight);
+            var top = scriptsElem.offsetTop;
+            var height = h - top;
+            var w = scriptsElem.offsetWidth;
+            if (!w) {
+                w = Math.max(1, frame.offsetWidth - scriptsElem.offsetLeft);
+            }
+            setCanvasSize(scriptsElem, w, height);
+            if (dc) {
+                setCanvasSize(dc, w, height);
+            }
+            if (ScriptsPane.scroll) {
+                ScriptsPane.scroll.update();
+            }
+            console.warn('fixDesync2: restored #scripts width to', w);
+        };
     }
 
     static gestureStart(e) {

--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -314,99 +314,12 @@ export default class ScratchJr {
         return gn(stage.currentPage.currentSpriteName).owner;
     }
 
-    // HACK: window.triggerDesync() reproduces the missing-watermark / disappearing-blocks bug.
-    // window.fixDesync() re-syncs using the visible script layer when possible (console).
-    // Requires 2+ sprites on the page. Swaps currentSpriteName to the OTHER
-    // sprite without toggling script-div visibility, so the user sees sprite A's
-    // scripts but drops land on sprite B's hidden div and vanish.
-    //
-    // window.triggerDesync2() reproduces the "zero-width scripts pane" bug: it sets #scripts
-    // and #scriptscontainer width to 0 the same way a bad resize can (see Page.js resize).
-    // window.fixDesync2() restores a non-zero width from layout for console recovery.
     static _initDebugHooks() {
         window.triggerDesync = function () {
-            var page = stage.currentPage;
-            var sprites = page.getSprites();
-            if (sprites.length < 2) {
-                console.error('Need at least 2 sprites on the page');
-                return;
-            }
-            var current = page.currentSpriteName;
-            var other = sprites.find(function (s) { return s !== current; });
-            // Swap active sprite to the other one (keeps getActiveScript() valid)
-            page.currentSpriteName = other;
-            // Clear watermark
-            var wm = ScriptsPane.watermark;
-            while (wm.childElementCount > 0) { wm.removeChild(wm.childNodes[0]); }
-            // Make switching sprites not fix it: remove the VISIBLE sprite's
-            // _scripts div so setActiveScript bails when you click its thumbnail
-            var visibleSc = gn(current + '_scripts');
-            if (visibleSc && visibleSc.parentNode) {
-                visibleSc.parentNode.removeChild(visibleSc);
-            }
-            console.warn('Active sprite is now', other, '(hidden scripts div).',
-                'Visible scripts from', current, 'are orphaned.',
-                'Clicking', current, 'thumbnail will not recover. Try dragging a block.');
-        };
-        // Prefer the script canvas that is actually visible (fixes model vs UI mismatch).
-        // Call from the console: fixDesync()
-        window.fixDesync = function () {
-            if (!stage || !stage.currentPage) {
-                console.warn('fixDesync: no active page');
-                return;
-            }
-            var dc = gn('scriptscontainer');
-            var spr = null;
-            var fromVisible = false;
-            var visibleCount = 0;
-            if (dc) {
-                for (var i = 0; i < dc.childElementCount; i++) {
-                    var node = dc.childNodes[i];
-                    if (!node.id || !/_scripts$/.test(node.id)) {
-                        continue;
-                    }
-                    if (window.getComputedStyle(node).visibility !== 'visible') {
-                        continue;
-                    }
-                    visibleCount++;
-                    if (!spr) {
-                        var sid = node.id.replace(/_scripts$/, '');
-                        var el = gn(sid);
-                        if (el && el.owner) {
-                            spr = el.owner;
-                            fromVisible = true;
-                        }
-                    }
-                }
-            }
-            if (visibleCount > 1) {
-                console.warn(
-                    'fixDesync: multiple visible script layers; using first:',
-                    spr && spr.id
-                );
-            }
-            if (!spr) {
-                spr = ScratchJr.getSprite();
-            }
-            if (spr) {
-                Thumbs.selectThisSprite(spr);
-                if (ScriptsPane.scroll) {
-                    ScriptsPane.scroll.update();
-                }
-                console.warn(
-                    'fixDesync: re-synced to',
-                    spr.id,
-                    fromVisible ? '(visible script layer)' : '(currentSpriteName / fallback)'
-                );
-            } else {
-                console.warn('fixDesync: could not resolve a sprite');
-            }
-        };
-        window.triggerDesync2 = function () {
             var scriptsElem = gn('scripts');
             var dc = gn('scriptscontainer');
             if (!scriptsElem) {
-                console.error('triggerDesync2: #scripts not found');
+                console.error('triggerDesync: #scripts not found');
                 return;
             }
             var h = Math.max(getDocumentHeight(), frame.offsetHeight);
@@ -416,16 +329,12 @@ export default class ScratchJr {
             if (dc) {
                 setCanvasSize(dc, 0, height);
             }
-            console.warn(
-                'triggerDesync2: scripts pane width forced to 0 (watermark clipped, drops may not land).',
-                'Call fixDesync2() to recover.'
-            );
         };
-        window.fixDesync2 = function () {
+        window.fixDesync = function () {
             var scriptsElem = gn('scripts');
             var dc = gn('scriptscontainer');
             if (!scriptsElem) {
-                console.warn('fixDesync2: #scripts not found');
+                console.warn('fixDesync: #scripts not found');
                 return;
             }
             var h = Math.max(getDocumentHeight(), frame.offsetHeight);
@@ -442,7 +351,6 @@ export default class ScratchJr {
             if (ScriptsPane.scroll) {
                 ScriptsPane.scroll.update();
             }
-            console.warn('fixDesync2: restored #scripts width to', w);
         };
     }
 

--- a/src/editor/ui/Palette.js
+++ b/src/editor/ui/Palette.js
@@ -93,6 +93,7 @@ export default class Palette {
             if (ScratchJr.shaking && (ScratchJr.shaking == ths)) {
                 Palette.removeSound(ths);
             } else {
+                ScriptsPane.ensureScriptsPaneWidth();
                 Events.startDrag(e, ths, Palette.prepareForDrag,
                     Palette.dropBlockFromPalette, ScriptsPane.draggingBlock, Palette.showHelp, Palette.startShaking);
             }

--- a/src/editor/ui/Scripts.js
+++ b/src/editor/ui/Scripts.js
@@ -94,6 +94,7 @@ export default class Scripts {
             // It's not clear to me why we would want this, and seems functional without it. -- TM
             //if ((ths.owner.blocktype == "repeat") && !hitTest(ths.childNodes[1], pixel)) continue;
             e.preventDefault();
+            ScriptsPane.ensureScriptsPaneWidth();
             Events.startDrag(e, ths, ScriptsPane.prepareToDrag,
                 ScriptsPane.dropBlock, ScriptsPane.draggingBlock, ScriptsPane.runBlock);
             return;

--- a/src/editor/ui/ScriptsPane.js
+++ b/src/editor/ui/ScriptsPane.js
@@ -80,6 +80,19 @@ export default class ScriptsPane {
         ScratchJr.userStart = true;
     }
 
+    // Restore #scripts width if 0 (bad resize); must run on mousedown, not in pickBlock
+    // (pickBlock runs only after Events.mouseMove passes the drag threshold).
+    static ensureScriptsPaneWidth() {
+        var scriptsEl = gn('scripts');
+        if (
+            scriptsEl &&
+            scriptsEl.offsetWidth === 0 &&
+            typeof window.fixDesync === 'function'
+        ) {
+            window.fixDesync();
+        }
+    }
+
     static prepareToDrag(e) {
         e.preventDefault();
         var pt = Events.getTargetPoint(e);

--- a/src/editor/ui/ScriptsPane.js
+++ b/src/editor/ui/ScriptsPane.js
@@ -80,8 +80,7 @@ export default class ScriptsPane {
         ScratchJr.userStart = true;
     }
 
-    // Restore #scripts width if 0 (bad resize); must run on mousedown, not in pickBlock
-    // (pickBlock runs only after Events.mouseMove passes the drag threshold).
+    // Restore #scripts width if 0 (possibly bc bad resize)
     static ensureScriptsPaneWidth() {
         var scriptsEl = gn('scripts');
         if (


### PR DESCRIPTION

More details in the loom but we may be getting this bug because the `scripts` element (the workspace area where blocks are dropped) width size is 0.  
Loom: https://www.loom.com/share/ec14cf1efcde4bb0808390fe3e704a98

I’m not entirely sure how users are reaching this state. AI suggested it’s due to window resizing, but I’m not convinced. Since SJR was originally an iPad app, resizing behavior may not be robust but that’s just a guess

Extra Context:
I wasn’t able to reproduce this locally but I did encounter it once in live during the hackathon and took a screenshot bc I noticed that the watermark was still in the dom. At the time, I didn’t fully understand what I was seeing or whether I wanted to pursue the issue so I refreshed the page. Later I noticed that the scripts value was 0. When I manually set the environment to 0 (`triggerDesync`), the behavior closely matched what I had observed in the bug.
<img width="844" height="309" alt="image" src="https://github.com/user-attachments/assets/0cc343ea-1d5a-42a3-8025-b1c38c49f788" />


**How to Test**
(Will remove this function once it's been approved but for testing convenience, keeping it in)
Open the console on a ScratchJr program 
Call triggerDesync()
Should put the program in that weird state
Move a block and it should fix the issue 



https://linear.app/codehs/issue/ENG-4501/scratchjr-non-working-character-glitch
https://linear.app/codehs/issue/FF-3694/scratchjr-program-issue-with-dragging-blocks-requires-refresh
https://linear.app/codehs/issue/ENG-9256/sprite-disappears-and-coding-blocks-do-not-stay-in-scratch-jr

